### PR TITLE
fixed a name change inconsistency in cusp 

### DIFF
--- a/toolbox/+otp/+cusp/+presets/Canonical.m
+++ b/toolbox/+otp/+cusp/+presets/Canonical.m
@@ -30,8 +30,8 @@ classdef Canonical < otp.cusp.CUSPProblem
             params.Epsilon = opts.epsilon;
             params.Sigma = opts.sigma;
             
-            ang = 2 * pi / opts.Size * (1:opts.Size).';
-            y0 = zeros(opts.Size, 1);
+            ang = 2 * pi / opts.N * (1:opts.N).';
+            y0 = zeros(opts.N, 1);
             a0 = -2*cos(ang);
             b0 = 2*sin(ang);
 


### PR DESCRIPTION
`Size` was renamed to   `N`, but the parsed options object was using the old names 